### PR TITLE
[add] #3 夏休みの開始日と終了日を選択できるようにする

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/lib/view/vacation_period_page.dart
+++ b/lib/view/vacation_period_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import 'package:svhw_app/constant/constant.dart';
 import 'package:svhw_app/provider/provider.dart';
 
@@ -9,12 +10,12 @@ class VacationPeriodPage extends ConsumerWidget {
   /// コンストラクタ
   const VacationPeriodPage({super.key});
 
-  Future<void> _selectDate(BuildContext context, WidgetRef ref) async {
-    final DateTime? selected = await showDatePicker(
+  Future<DateTime?> _selectDate(BuildContext context) async {
+    return await showDatePicker(
       context: context,
       initialDate: DateTime.now(),
-      firstDate: DateTime(2021),
-      lastDate: DateTime(2022),
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2024),
     );
   }
 
@@ -25,36 +26,83 @@ class VacationPeriodPage extends ConsumerWidget {
         title: const Text('夏休みの期間登録画面'),
       ),
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Constant.vacationPeriodPageVerticalPadding, vertical: 0),
+        padding: const EdgeInsets.symmetric(
+            horizontal: Constant.vacationPeriodPageVerticalPadding,
+            vertical: 0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const Text(Constant.vacationStartDateMessage),
-            TextField(
-              controller: ref.watch(AppProvider.startDateControllerStateProvider),
-              // タップ時にキーワードを表示しないよう制御
-              focusNode: AlwaysDisabledFocusNode(),
-              onTap: () => _selectDate(context, ref),
-              style: const TextStyle(
-                fontSize: 20.0,
-                height: 1.0,
-                color: Colors.black,
-              ),
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  height: 60,
+                  child: TextField(
+                    controller:
+                        ref.watch(AppProvider.startDateControllerStateProvider),
+                    // タップ時にキーワードを表示しないよう制御
+                    focusNode: AlwaysDisabledFocusNode(),
+                    style: const TextStyle(
+                      fontSize: 20.0,
+                      height: 1.0,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                    onPressed: () async {
+                      Future<DateTime?> selectedDate = _selectDate(context);
+                      await selectedDate.then((value) {
+                        if (value != DateTime.now()) {
+                          TextEditingController controller = ref.read(
+                              AppProvider.startDateControllerStateProvider);
+                          DateFormat formatter =
+                          DateFormat('yyyy/MM/dd', 'ja-JP');
+                          controller.text = formatter.format(value!);
+                        }
+                      });
+                    },
+                    child: const Icon(Icons.calendar_today)),
+              ],
             ),
             const SizedBox(
               height: 100,
             ),
             const Text(Constant.vacationEndDateMessage),
-            TextField(
-              controller: ref.watch(AppProvider.endDateControllerStateProvider),
-              // タップ時にキーワードを表示しないよう制御
-              focusNode: AlwaysDisabledFocusNode(),
-              style: const TextStyle(
-                fontSize: 20.0,
-                height: 1.0,
-                color: Colors.black,
-              ),
+            Row(
+              children: [
+                SizedBox(
+                  width: 120,
+                  height: 60,
+                  child: TextField(
+                    controller:
+                        ref.watch(AppProvider.endDateControllerStateProvider),
+                    // タップ時にキーワードを表示しないよう制御
+                    focusNode: AlwaysDisabledFocusNode(),
+                    style: const TextStyle(
+                      fontSize: 20.0,
+                      height: 1.0,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                    onPressed: () async {
+                      Future<DateTime?> selectedDate = _selectDate(context);
+                      await selectedDate.then((value) {
+                        if (value != DateTime.now()) {
+                          TextEditingController controller = ref.read(
+                              AppProvider.endDateControllerStateProvider);
+                          DateFormat formatter =
+                          DateFormat('yyyy/MM/dd', 'ja-JP');
+                          controller.text = formatter.format(value!);
+                        }
+                      });
+                    },
+                    child: const Icon(Icons.calendar_today)),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
## 概要
日付け表示フィールドの横に日付け選択ボタンを追加し、ボタンをクリックすると
日付け選択ポップアップを表示するようにしました。
日付け選択後は、 yyyy/MM/dd の形式でフォーマットしてプロバイダーに登録します。