### PR TITLE
[add] #3 日付のフォーマットを yyyy/MM/dd に統一する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart';
 
 /// アプリ内で使用する定数を定義します。
 class Constant {
+  /// 現在の西暦
+  static final int currentYear = DateTime.now().year;
+
   /// 31日
   static const int thirtyOneDays = 31;
 
@@ -14,6 +18,9 @@ class Constant {
 
   /// メッセージ：夏休みの終わり
   static const String vacationEndDateMessage = '夏休みのおわり';
+
+  /// 本アプリで使用する日付のフォーマット
+  static final DateFormat formatter = DateFormat('yyyy/MM/dd', 'ja-JP');
 
   /// 多言語対応
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = [

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -16,14 +16,14 @@ class AppProvider {
 
   static final AutoDisposeStateProvider<TextEditingController>
       startDateControllerStateProvider = StateProvider.autoDispose((ref) {
-    return TextEditingController(text: DateTime.now().toString());
+    return TextEditingController(
+        text: Constant.formatter.format(DateTime.now()));
   });
 
   static final AutoDisposeStateProvider<TextEditingController>
       endDateControllerStateProvider = StateProvider.autoDispose((ref) {
     return TextEditingController(
-        text: DateTime(
-                DateTime.now().year, DateTime.august, Constant.thirtyOneDays)
-            .toString());
+        text: Constant.formatter.format(DateTime(
+            DateTime.now().year, DateTime.august, Constant.thirtyOneDays)));
   });
 }

--- a/lib/view/vacation_period_page.dart
+++ b/lib/view/vacation_period_page.dart
@@ -10,15 +10,6 @@ class VacationPeriodPage extends ConsumerWidget {
   /// コンストラクタ
   const VacationPeriodPage({super.key});
 
-  Future<DateTime?> _selectDate(BuildContext context) async {
-    return await showDatePicker(
-      context: context,
-      initialDate: DateTime.now(),
-      firstDate: DateTime(2020),
-      lastDate: DateTime(2024),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
@@ -58,9 +49,7 @@ class VacationPeriodPage extends ConsumerWidget {
                         if (value != DateTime.now()) {
                           TextEditingController controller = ref.read(
                               AppProvider.startDateControllerStateProvider);
-                          DateFormat formatter =
-                          DateFormat('yyyy/MM/dd', 'ja-JP');
-                          controller.text = formatter.format(value!);
+                          controller.text = Constant.formatter.format(value!);
                         }
                       });
                     },
@@ -93,11 +82,9 @@ class VacationPeriodPage extends ConsumerWidget {
                       Future<DateTime?> selectedDate = _selectDate(context);
                       await selectedDate.then((value) {
                         if (value != DateTime.now()) {
-                          TextEditingController controller = ref.read(
-                              AppProvider.endDateControllerStateProvider);
-                          DateFormat formatter =
-                          DateFormat('yyyy/MM/dd', 'ja-JP');
-                          controller.text = formatter.format(value!);
+                          TextEditingController controller = ref
+                              .read(AppProvider.endDateControllerStateProvider);
+                          controller.text = Constant.formatter.format(value!);
                         }
                       });
                     },
@@ -109,6 +96,16 @@ class VacationPeriodPage extends ConsumerWidget {
       ),
     );
   }
+}
+
+/// 日付選択ポップアップを開いて選択した日付を返します。
+Future<DateTime?> _selectDate(BuildContext context) async {
+  return await showDatePicker(
+    context: context,
+    initialDate: DateTime.now(),
+    firstDate: DateTime(Constant.currentYear),
+    lastDate: DateTime(Constant.currentYear),
+  );
 }
 
 /// テキストフィールドタップ時にキーボードを表示しないよう制御するクラスです。


### PR DESCRIPTION
## 概要
夏休みの期間登録画面のプロバイダーで初期値登録時にフォーマットを指定するようにしました。