### PR TITLE
[add] #5 登録する宿題を選択するダイアログを追加する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -4,6 +4,18 @@ import 'package:intl/intl.dart';
 
 /// アプリ内で使用する定数を定義します。
 class Constant {
+  /// 多言語対応
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = [
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// 本アプリで対応する言語
+  static const List<Locale> supportedLocales = [
+    Locale('ja', ''),
+    Locale('en', ''),
+  ];
+
   /// 現在の西暦
   static final int currentYear = DateTime.now().year;
 
@@ -28,18 +40,18 @@ class Constant {
   /// メッセージ：宿題の追加
   static const String addSubjectMessage = '宿題の追加';
 
+  /// メッセージ：追加する宿題を選択します。
+  static const String selectHomeworkMessage = '追加する宿題を選択します。';
+
   /// 本アプリで使用する日付のフォーマット
   static final DateFormat formatter = DateFormat('yyyy/MM/dd', 'ja-JP');
 
-  /// 多言語対応
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = [
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
-
-  /// 本アプリで対応する言語
-  static const List<Locale> supportedLocales = [
-    Locale('ja', ''),
-    Locale('en', ''),
+  /// 本アプリで選択できる宿題の教科
+  static final List<String> subjects = [
+    '国語',
+    '算数',
+    '英語',
+    '理科',
+    '社会',
   ];
 }

--- a/lib/provider/notifier/homework_notifier.dart
+++ b/lib/provider/notifier/homework_notifier.dart
@@ -4,5 +4,5 @@ import '../../model/homework.dart';
 
 /// 登録予定の宿題の StateNotifier です。
 class HomeworkNotifier extends StateNotifier<List<Map<String, HomeworkType>>> {
-  HomeworkNotifier(): super(const []);
+  HomeworkNotifier(): super([]);
 }

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
 import 'package:svhw_app/provider/notifier/homework_notifier.dart';
 import 'package:svhw_app/provider/notifier/vacation_period_notifier.dart';
@@ -35,6 +36,6 @@ class AppProvider {
   });
 
   /// 登録する宿題を管理するプロバイダーです。
-  static final StateNotifierProvider homeworkProvider =
-      StateNotifierProvider((ref) => HomeworkNotifier());
+  static final homeworkProvider =
+      Provider<List<Map<String, HomeworkType>>>((ref) => []);
 }

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -4,6 +4,8 @@ import 'package:svhw_app/constant/constant.dart';
 import 'package:svhw_app/provider/provider.dart';
 import 'package:svhw_app/view/page_util.dart';
 
+import '../model/homework.dart';
+
 /// 夏休みの宿題を登録する画面です。
 /// 夏休みの情報を登録するときにだけ遷移できる画面で
 /// 夏休みの期間登録画面から遷移します。
@@ -12,7 +14,8 @@ class RegisterHomeworkPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final homeworks = ref.watch(AppProvider.homeworkProvider);
+    final List<Map<String, HomeworkType>> homeworks =
+        ref.watch(AppProvider.homeworkProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -28,11 +31,14 @@ class RegisterHomeworkPage extends ConsumerWidget {
           children: [
             // 空のリストを用意(プロバイダーがいいか)
             // 宿題追加で追加された教科の名称を一覧で表示していく
-            TextButton(
-                onPressed: () {
-                  print('科目選択のポップアップを開くよー。');
-                },
-                child: const Text('${Constant.addSubjectMessage}  +')),
+            ListView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: homeworks.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return Text('$homeworks[index]');
+                }),
+            const _SelectHomeworkDialogButton(),
             PageUtil.getSizedBox(),
             Container(
               margin: const EdgeInsets.only(left: 250.0),
@@ -45,6 +51,41 @@ class RegisterHomeworkPage extends ConsumerWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// 追加する宿題を選択するダイアログを開くボタンです。
+class _SelectHomeworkDialogButton extends ConsumerWidget {
+  const _SelectHomeworkDialogButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<Map<String, HomeworkType>> homework =
+        ref.watch(AppProvider.homeworkProvider);
+
+    return TextButton(
+      onPressed: () => showDialog<String>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          title: const Text(Constant.selectHomeworkMessage),
+          content: const Text('AlertDialog description'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(context, 'Cancel'),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, 'OK'),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+      child: const Text(
+        '${Constant.addSubjectMessage}  +',
+        style: TextStyle(fontSize: 20),
       ),
     );
   }


### PR DESCRIPTION
## 概要
登録する宿題を選択するダイアログを追加します。
追加する宿題と形式はプルダウンで選択できるようにする想定です。
選択された宿題は元画面にリスト形式で表示し、リスト本体はプロバイダーで状態管理します。