### PR TITLE
[add] #5 追加した宿題を元画面のリストに反映する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -58,6 +58,7 @@ class Constant {
     '社会',
   ];
 
+  /// 科目選択プルダウンで表示するリスト
   static final List<String> dropDownItems = [
     dropDownHintMessage,
     ... subjects

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -35,10 +35,13 @@ class AppProvider {
   });
 
   /// 登録する宿題を管理するプロバイダーです。
-  static final Provider<List<Map<String, HomeworkType>>> homeworkProvider =
-      Provider<List<Map<String, HomeworkType>>>((ref) => []);
+  static final StateProvider<List<Map<String, HomeworkType>>> homeworkProvider =
+      StateProvider<List<Map<String, HomeworkType>>>((ref) => []);
 
   /// 科目選択プルダウンの選択値を管理するプロバイダーです。
   static StateProvider<String> selectSubjectProvider =
       StateProvider<String>((ref) => Constant.dropDownItems[0]);
+
+  static StateProvider<HomeworkType> selectTypeProvider =
+      StateProvider<HomeworkType>((ref) => HomeworkType.text);
 }

--- a/lib/view/parts/dropdown_button.dart
+++ b/lib/view/parts/dropdown_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/provider/provider.dart';
 
 import '../../../../../constant/constant.dart';
+import '../../model/homework.dart';
 
 /// 科目を選択するプルダウンのWidgetです。
 class SubjectDropdownButton extends ConsumerWidget {
@@ -15,11 +16,33 @@ class SubjectDropdownButton extends ConsumerWidget {
     return DropdownButton<String>(
       value: selectSubject,
       onChanged: (value) =>
-      ref.read(AppProvider.selectSubjectProvider.notifier).state = value!,
+          ref.read(AppProvider.selectSubjectProvider.notifier).state = value!,
       items: Constant.dropDownItems.map<DropdownMenuItem<String>>((subject) {
         return DropdownMenuItem(
           value: subject,
           child: Text(subject),
+        );
+      }).toList(),
+    );
+  }
+}
+
+/// 宿題の種別を選択するプルダウンのWidgetです。
+class HomeworkTypeDropdownButton extends ConsumerWidget {
+  const HomeworkTypeDropdownButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final HomeworkType selectType = ref.watch(AppProvider.selectTypeProvider);
+
+    return DropdownButton<HomeworkType>(
+      value: selectType,
+      onChanged: (type) =>
+          ref.read(AppProvider.selectTypeProvider.notifier).state = type!,
+      items: HomeworkType.values.map<DropdownMenuItem<HomeworkType>>((type) {
+        return DropdownMenuItem(
+          value: type,
+          child: Text(type.typeValue),
         );
       }).toList(),
     );

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/constant/constant.dart';
 import 'package:svhw_app/provider/provider.dart';
 import 'package:svhw_app/view/page_util.dart';
-import 'package:svhw_app/view/parts/subject_dropdown_button.dart';
+import 'package:svhw_app/view/parts/dropdown_button.dart';
 
 import '../model/homework.dart';
 
@@ -37,7 +37,18 @@ class RegisterHomeworkPage extends ConsumerWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: homeworks.length,
                 itemBuilder: (BuildContext context, int index) {
-                  return Text('$homeworks[index]');
+                  Map<String, HomeworkType> homework = homeworks[index];
+                  String subject = '';
+                  homework.forEach((key, value) {
+                    subject = key;
+                  });
+                  return Text(
+                    subject,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 20,
+                    ),
+                  );
                 }),
             const _SelectHomeworkDialogButton(),
             PageUtil.getSizedBox(),
@@ -63,22 +74,36 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<Map<String, HomeworkType>> homework =
-        ref.watch(AppProvider.homeworkProvider);
-
     return TextButton(
       onPressed: () => showDialog<String>(
         context: context,
         builder: (BuildContext context) => AlertDialog(
           title: const Text(Constant.selectHomeworkMessage),
-          content: const SubjectDropdownButton(),
+          content: SizedBox(
+            height: 100,
+            child: Column(
+              children: const [
+                SubjectDropdownButton(),
+                HomeworkTypeDropdownButton(),
+              ],
+            ),
+          ),
           actions: <Widget>[
             TextButton(
               onPressed: () => Navigator.pop(context, 'Cancel'),
               child: const Text('Cancel'),
             ),
             TextButton(
-              onPressed: () => Navigator.pop(context, 'OK'),
+              onPressed: () {
+                final String selectSubject =
+                    ref.read(AppProvider.selectSubjectProvider);
+                final HomeworkType selectType =
+                    ref.read(AppProvider.selectTypeProvider);
+                List<Map<String, HomeworkType>> selectedHomework =
+                    ref.read(AppProvider.homeworkProvider);
+                selectedHomework.add({selectSubject: selectType});
+                Navigator.pop(context, 'OK');
+              },
               child: const Text('OK'),
             ),
           ],


### PR DESCRIPTION
## 概要
ポップアップで選択した宿題を元画面のリストに表示するようにしました。
ただ、リアルタイムの反映はまだできておらず、一度画面を再表示しないと反映されません。