### PR TITLE
[add] #5 追加した宿題を元画面のリストに即時反映するのリファクタリング

### DIFF
--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -30,8 +30,6 @@ class RegisterHomeworkPage extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            // 空のリストを用意(プロバイダーがいいか)
-            // 宿題追加で追加された教科の名称を一覧で表示していく
             ListView.builder(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
@@ -99,10 +97,10 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
                     ref.read(AppProvider.selectSubjectProvider);
                 final HomeworkType selectType =
                     ref.read(AppProvider.selectTypeProvider);
-                List<Map<String, HomeworkType>> homeworks = ref.read(AppProvider.homeworkProvider);
-                homeworks.add({selectSubject: selectType});
+                List<Map<String, HomeworkType>> homeworks =
+                    ref.read(AppProvider.homeworkProvider);
                 ref.read(AppProvider.homeworkProvider.notifier).state =
-                   [...homeworks];
+                [...homeworks,...[{selectSubject : selectType}]];
                 Navigator.pop(context, 'OK');
               },
               child: const Text('OK'),


### PR DESCRIPTION
## 概要
プロバイダーのリストと選択した宿題科目の結合方法を修正し、コード数を減らしました。
プロバイダーから取れたリストに add() するのではなく、スプレッド(...)演算子を組み合わせて
リスト同士を結合するようにしました。