### PR TITLE
[add] #5 登録する宿題の管理をMapからHomeworkに変更する

### DIFF
--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
+import 'package:svhw_app/provider/notifier/homework_notifier.dart';
 import 'package:svhw_app/provider/notifier/vacation_period_notifier.dart';
 
 import '../constant/constant.dart';
@@ -35,13 +36,15 @@ class AppProvider {
   });
 
   /// 登録する宿題を管理するプロバイダーです。
-  static final StateProvider<List<Map<String, HomeworkType>>> homeworkProvider =
-      StateProvider<List<Map<String, HomeworkType>>>((ref) => []);
+  static final StateNotifierProvider<HomeworkNotifier, List<Homework>>
+      homeworksProvider =
+      StateNotifierProvider<HomeworkNotifier, List<Homework>>(
+          (ref) => HomeworkNotifier());
 
   /// 科目選択プルダウンの選択値を管理するプロバイダーです。
-  static AutoDisposeStateProvider<String> selectSubjectProvider =
+  static final AutoDisposeStateProvider<String> selectSubjectProvider =
       StateProvider.autoDispose((ref) => Constant.dropDownItems[0]);
 
-  static AutoDisposeStateProvider<HomeworkType> selectTypeProvider =
+  static final AutoDisposeStateProvider<HomeworkType> selectTypeProvider =
       StateProvider.autoDispose((ref) => HomeworkType.text);
 }

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -15,8 +15,8 @@ class RegisterHomeworkPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    List<Map<String, HomeworkType>> homeworks =
-        ref.watch(AppProvider.homeworkProvider);
+    List<Homework> homeworks =
+        ref.watch(AppProvider.homeworksProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -35,13 +35,10 @@ class RegisterHomeworkPage extends ConsumerWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: homeworks.length,
                 itemBuilder: (BuildContext context, int index) {
-                  Map<String, HomeworkType> homework = homeworks[index];
-                  String subject = '';
-                  homework.forEach((key, value) {
-                    subject = key;
-                  });
+                  Homework homework = homeworks[index];
+
                   return Text(
-                    subject,
+                    homework.subject,
                     textAlign: TextAlign.center,
                     style: const TextStyle(
                       fontSize: 20,
@@ -97,10 +94,10 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
                     ref.read(AppProvider.selectSubjectProvider);
                 final HomeworkType selectType =
                     ref.read(AppProvider.selectTypeProvider);
-                List<Map<String, HomeworkType>> homeworks =
-                    ref.read(AppProvider.homeworkProvider);
-                ref.read(AppProvider.homeworkProvider.notifier).state =
-                [...homeworks,...[{selectSubject : selectType}]];
+                ref.read(AppProvider.homeworksProvider.notifier).addHomeWork(
+                    Homework(
+                        subject: selectSubject,
+                        homeworkType: selectType.typeInt));
                 Navigator.pop(context, 'OK');
               },
               child: const Text('OK'),


### PR DESCRIPTION
## 概要
登録する宿題を StateProvider<List<Map<String, HomeworkType>>> で管理していましたが、StateNotifierProvider<HomeworkNotifier, List<Homework>> で管理するようにしました。
そうすることで、宿題の追加、削除、DBの登録をStateNotifier経由で簡単に行えるようになります。