### PR TITLE
[add] #5 登録する宿題の一覧にSlidableを導入する

### DIFF
--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:svhw_app/constant/constant.dart';
 import 'package:svhw_app/provider/provider.dart';
 import 'package:svhw_app/view/page_util.dart';
@@ -15,8 +16,7 @@ class RegisterHomeworkPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    List<Homework> homeworks =
-        ref.watch(AppProvider.homeworksProvider);
+    List<Homework> homeworks = ref.watch(AppProvider.homeworksProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -30,29 +30,55 @@ class RegisterHomeworkPage extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: homeworks.length,
-                itemBuilder: (BuildContext context, int index) {
-                  Homework homework = homeworks[index];
+            SlidableAutoCloseBehavior(
+              child: ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: homeworks.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    Homework homework = homeworks[index];
 
-                  return Text(
-                    homework.subject,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 20,
-                    ),
-                  );
-                }),
+                    return Slidable(
+                        key: UniqueKey(),
+                        endActionPane: ActionPane(
+                          motion: const ScrollMotion(),
+                          children: [
+                            SlidableAction(
+                              onPressed: (context) {
+                                ref.read(AppProvider.homeworksProvider.notifier)
+                                    .removeHomeWork(homework.id);
+                              },
+                              flex: 2,
+                              backgroundColor: const Color(0xFFFE4A49),
+                              foregroundColor: Colors.white,
+                              icon: Icons.delete,
+                            ),
+                          ],
+                        ),
+                        child: Container(
+                          alignment: Alignment.center,
+                          child: Text(
+                            homework.subject,
+                            style: const TextStyle(
+                              fontSize: 20,
+                            ),
+                          ),
+                        ));
+                  }),
+            ),
             const _SelectHomeworkDialogButton(),
             PageUtil.getSizedBox(),
             Container(
               margin: const EdgeInsets.only(left: 250.0),
               child: ElevatedButton(
-                  // 登録タップ時に期間のデータ登録
+                  // 登録タップ時に宿題、期間のデータ登録
                   onPressed: () {
-                    print('夏休みの期間と宿題を登録するよー。');
+                    ref
+                        .read(AppProvider.periodProvider.notifier)
+                        .insertPeriod();
+                    ref
+                        .read(AppProvider.homeworksProvider.notifier)
+                        .insertHomeworks();
                   },
                   child: const Text(Constant.registerMessage)),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.17.0
+
+  flutter_slidable: ^2.0.0
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
## 概要
登録予定の宿題を表示するリストにSlidableを導入し、削除できるようにしました。
Slidableを導入すると科目名を表示するText Widget が左寄せになりスライドがうまく表示されなかったため、
Container Widget でラップし、中央寄せにしました。