### PR TITLE
[add] #6 進捗確認画面で確認用に期間、登録された宿題を表示する

### DIFF
--- a/lib/model/vacation_period.dart
+++ b/lib/model/vacation_period.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/cupertino.dart';
 import 'package:objectbox/objectbox.dart';
+
+import '../constant/constant.dart';
 
 /// 夏休みの期間のモデルです
 @Entity()
@@ -16,6 +17,12 @@ class VacationPeriod {
 
   /// コンストラクタ
   VacationPeriod({this.id = 0, required this.startDate, required this.endDate});
+
+  /// 表示用(文字列)の開始日を返します。
+  String get dispStartDate => Constant.formatter.format(startDate);
+
+  /// 表示用(文字列)の終了日を返します。
+  String get dispEndDate => Constant.formatter.format(endDate);
 
   /// オブジェクトのコピーを行います。
   VacationPeriod copyWith({DateTime? startDate, DateTime? endDate}) {

--- a/lib/repository/homepage_repository.dart
+++ b/lib/repository/homepage_repository.dart
@@ -13,7 +13,7 @@ abstract class HomePageRepository {
   VacationPeriod vacationPeriod();
 
   /// 登録されている夏休みの宿題一覧を返します。
-  List<Homework> registeredHomework();
+  List<Homework> registeredHomeworks();
 }
 
 class HomePageRepositoryImpl implements HomePageRepository {
@@ -25,7 +25,7 @@ class HomePageRepositoryImpl implements HomePageRepository {
   }
 
   @override
-  List<Homework> registeredHomework() {
+  List<Homework> registeredHomeworks() {
     final Box<Homework> homeworkBox = store.box<Homework>();
     final List<Homework> homeworks = homeworkBox.getAll();
     return homeworks;

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:svhw_app/model/homework.dart';
+import 'package:svhw_app/model/vacation_period.dart';
+import 'package:svhw_app/repository/homepage_repository.dart';
 
 /// 現在の宿題の状況を確認できるページです。
 /// 宿題が既に登録されている場合は最初に表示されるページになります。
@@ -9,12 +12,29 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final HomePageRepository homePageRepository = HomePageRepositoryImpl();
+    final VacationPeriod period = homePageRepository.vacationPeriod();
+    final List<Homework> homeworks = homePageRepository.registeredHomeworks();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('宿題の進捗確認画面'),
       ),
-      body: const Center(
-        child: Text('ホーム画面だよー。'),
+      body: Center(
+        child: Column(
+          children: [
+            const Text('ホーム画面だよー。'),
+            Text('夏休みの始まり -> ${period.dispStartDate}'),
+            Text('夏休みの終わり -> ${period.dispEndDate}'),
+            ListView.builder(
+              shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: homeworks.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return Text(homeworks[index].subject);
+                })
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 概要
夏休みの期間登録画面、夏休みの宿題登録画面の動作確認用に登録済みの情報を表示する処理を
宿題の進捗確認画面に追加しました。