### PR TITLE
[add] #6 天気予報のアイコンを取得するクラスを追加する

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -26,7 +26,9 @@ class HomePage extends ConsumerWidget {
             const Text('ホーム画面だよー。'),
             Row(
               children: [
-                Container(padding: const EdgeInsets.only(left: 8), width: 300, child: const VacationPeriodIndicator()),
+                Container(padding: const EdgeInsets.only(left: 8),
+                    width: 300,
+                    child: const VacationPeriodIndicator()),
                 const Expanded(child: Icon(Icons.sunny, color: Colors.orange,)),
               ],
             ),

--- a/lib/view/parts/icon.dart
+++ b/lib/view/parts/icon.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// その日の天気予報を取得し、天気に合ったアイコンを
+/// 取得できるクラスです。
+class WeatherIcon extends StatelessWidget {
+  const WeatherIcon({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    throw UnimplementedError();
+  }
+}
+
+/// 天気の種類の Enum です。
+enum Weather { sunny, cloudy, rainy }
+
+/// Weather のエクステンションです。
+extension WeatherExtension on Weather {
+  static final icons = {
+    Weather.sunny: const Icon(Icons.wb_sunny, color: Colors.redAccent),
+    Weather.cloudy: const Icon(Icons.wb_cloudy, color: Colors.white38),
+    Weather.rainy: const Icon(Icons.beach_access, color: Colors.blue)
+  };
+}

--- a/lib/view/parts/progress_indicator.dart
+++ b/lib/view/parts/progress_indicator.dart
@@ -21,9 +21,7 @@ class VacationPeriodIndicator extends StatelessWidget {
   double _indicatorValue() {
     final HomePageRepository homePageRepository = HomePageRepositoryImpl();
     final VacationPeriod period = homePageRepository.vacationPeriod();
-    final testDate = DateTime(DateTime.now().year, DateTime.august, 5);
-    int lapsedDays = testDate.difference(period.startDate).inDays;
-    // int lapsedDays = DateTime.now().difference(period.startDate).inDays;
+    int lapsedDays = DateTime.now().difference(period.startDate).inDays;
     return lapsedDays / period.vacationDays();
   }
 }


### PR DESCRIPTION
## 概要
緯度経度をもとに取得したその日の天気に対応するアイコンを返すクラスを追加しました。
天気は 晴れ、曇り、雨 の三種類で分類する予定です。
夏休みの使用を想定しているので、雪は考慮しません。
雨を表すアイコンだけ Flutter 標準の Icons に含まれていないため、どのアイコンをどこから取得するかは
検討が必要です。