### PR TITLE
[add] #6 JSONファイルを読み込んでAPIキーを取得する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ app.*.map.json
 /android/app/release
 
 # API で使用するキーを管理するファイルを除外
-api_keys.json
+json/api_keys.json

--- a/lib/provider/notifier/api_json_repository_notifier.dart
+++ b/lib/provider/notifier/api_json_repository_notifier.dart
@@ -4,20 +4,42 @@ import '../../repository/api_json_repository.dart';
 
 ///  api_key.json の読み込みを行うリポジトリの StateNotifier です。
 class ApiJsonRepositoryNotifier
-    extends StateNotifier<Provider<ApiJsonRepositoryImpl>> {
-  ApiJsonRepositoryNotifier()
-      : super(Provider<ApiJsonRepositoryImpl>((_) => ApiJsonRepositoryImpl()));
+    extends StateNotifier<AsyncValue<List<dynamic>>> {
+  ApiJsonRepositoryNotifier(this._apiJsonRepository)
+      : super(const AsyncValue.loading()) {
+    _fetchJsonFile();
+  }
+
+  /// api_key.json を読み込むリポジトリー
+  final ApiJsonRepositoryImpl _apiJsonRepository;
 
   /// JSON の読み込み処理の結果を AsyncValue で返します。
-  FutureProvider<void> fetchJsonFile() {
-    return FutureProvider<void>((ref) async {
-      final apiJsonRepository = ref.read(state);
-      apiJsonRepository.fetchJsonFile();
-    });
+  Future<void> _fetchJsonFile() async {
+    try {
+      final jsonData = await _apiJsonRepository.fetchJsonFile();
+      state = AsyncValue.data(jsonData);
+    } catch (error) {
+      state = AsyncValue.error(
+          error, StackTrace.fromString('ファイルの読み込み中にエラーが発生しました。'));
+    }
   }
 
   /// 指定したAPI名のキーを取得します。
-  String getKeyByApiName(WidgetRef ref, String apiName) {
-    return ref.read(state).getKeyByApiName(apiName);
+  String getKeyByApiName(String apiName) {
+    List<dynamic> jsonData = state.value ?? [];
+
+    if (apiName.isEmpty) {
+      return '';
+    }
+    if (jsonData.isEmpty) {
+      return '';
+    }
+
+    for (Map<String, dynamic> element in jsonData) {
+      if (apiName == element['name']) {
+        return element['key'];
+      }
+    }
+    return '';
   }
 }

--- a/lib/provider/notifier/api_json_repository_notifier.dart
+++ b/lib/provider/notifier/api_json_repository_notifier.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../repository/api_json_repository.dart';
+
+///  api_key.json の読み込みを行うリポジトリの StateNotifier です。
+class ApiJsonRepositoryNotifier
+    extends StateNotifier<Provider<ApiJsonRepositoryImpl>> {
+  ApiJsonRepositoryNotifier()
+      : super(Provider<ApiJsonRepositoryImpl>((_) => ApiJsonRepositoryImpl()));
+
+  /// JSON の読み込み処理の結果を AsyncValue で返します。
+  FutureProvider<void> fetchJsonFile() {
+    return FutureProvider<void>((ref) async {
+      final apiJsonRepository = ref.read(state);
+      apiJsonRepository.fetchJsonFile();
+    });
+  }
+
+  /// 指定したAPI名のキーを取得します。
+  String getKeyByApiName(WidgetRef ref, String apiName) {
+    return ref.read(state).getKeyByApiName(apiName);
+  }
+}

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -2,8 +2,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
+import 'package:svhw_app/provider/notifier/api_json_repository_notifier.dart';
 import 'package:svhw_app/provider/notifier/homework_notifier.dart';
 import 'package:svhw_app/provider/notifier/vacation_period_notifier.dart';
+import 'package:svhw_app/repository/api_json_repository.dart';
 
 import '../constant/constant.dart';
 
@@ -47,4 +49,11 @@ class AppProvider {
 
   static final AutoDisposeStateProvider<HomeworkType> selectTypeProvider =
       StateProvider.autoDispose((ref) => HomeworkType.text);
+
+  /// api_key.json の読み込みを行うリポジトリのプロバイダーです。
+  static final StateNotifierProvider<ApiJsonRepositoryNotifier,
+          Provider<ApiJsonRepositoryImpl>> apiJsonNotifierProvider =
+      StateNotifierProvider<ApiJsonRepositoryNotifier,
+              Provider<ApiJsonRepositoryImpl>>(
+          (ref) => ApiJsonRepositoryNotifier());
 }

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -14,46 +14,49 @@ class AppProvider {
   /// 夏休みの期間のプロバイダーです。
   /// 夏休みの開始日と終了日の状態を監視します。
   /// 夏休みの期間登録画面で使用します。
-  static final StateNotifierProvider<VacationPeriodNotifier, VacationPeriod>
-      periodProvider =
+  static final periodProvider =
       StateNotifierProvider<VacationPeriodNotifier, VacationPeriod>((ref) {
     return VacationPeriodNotifier();
   });
 
   /// 夏休みの期間登録画面の入力フィールド
   /// 夏休みの開始日のプロバイダーです。
-  static final AutoDisposeStateProvider<TextEditingController>
-      startDateControllerStateProvider = StateProvider.autoDispose((ref) {
+  static final startDateControllerStateProvider =
+      StateProvider.autoDispose((ref) {
     return TextEditingController(
         text: Constant.formatter.format(DateTime.now()));
   });
 
   /// 夏休みの期間登録画面の入力フィールド
   /// 夏休みの終了日のプロバイダーです。
-  static final AutoDisposeStateProvider<TextEditingController>
-      endDateControllerStateProvider = StateProvider.autoDispose((ref) {
+  static final endDateControllerStateProvider =
+      StateProvider.autoDispose((ref) {
     return TextEditingController(
         text: Constant.formatter.format(DateTime(
             DateTime.now().year, DateTime.august, Constant.thirtyOneDays)));
   });
 
   /// 登録する宿題を管理するプロバイダーです。
-  static final StateNotifierProvider<HomeworkNotifier, List<Homework>>
-      homeworksProvider =
+  static final homeworksProvider =
       StateNotifierProvider<HomeworkNotifier, List<Homework>>(
           (ref) => HomeworkNotifier());
 
   /// 科目選択プルダウンの選択値を管理するプロバイダーです。
-  static final AutoDisposeStateProvider<String> selectSubjectProvider =
+  static final selectSubjectProvider =
       StateProvider.autoDispose((ref) => Constant.dropDownItems[0]);
 
-  static final AutoDisposeStateProvider<HomeworkType> selectTypeProvider =
+  static final selectTypeProvider =
       StateProvider.autoDispose((ref) => HomeworkType.text);
 
   /// api_key.json の読み込みを行うリポジトリのプロバイダーです。
-  static final StateNotifierProvider<ApiJsonRepositoryNotifier,
-          Provider<ApiJsonRepositoryImpl>> apiJsonNotifierProvider =
-      StateNotifierProvider<ApiJsonRepositoryNotifier,
-              Provider<ApiJsonRepositoryImpl>>(
-          (ref) => ApiJsonRepositoryNotifier());
+  static final _apiJsonRepositoryProvider =
+      Provider<ApiJsonRepositoryImpl>((ref) {
+    return ApiJsonRepositoryImpl();
+  });
+
+  /// api_key.json の読み込みを管理するのプロバイダーです。
+  static final apiJsonNotifierProvider = StateNotifierProvider<
+          ApiJsonRepositoryNotifier, AsyncValue<List<dynamic>>>(
+      (ref) =>
+          ApiJsonRepositoryNotifier(ref.watch(_apiJsonRepositoryProvider)));
 }

--- a/lib/repository/api_json_repository.dart
+++ b/lib/repository/api_json_repository.dart
@@ -24,10 +24,9 @@ class ApiJsonRepositoryImpl implements ExternalJsonRepository {
   }
 
   @override
-  Future<void> fetchJsonFile() async {
-    if (_jsonArray.isNotEmpty) return;
-    String jsonString = await rootBundle.loadString(_filePath);
-    _jsonArray = json.decode(jsonString);
+  Future<List<dynamic>> fetchJsonFile() async {
+      String jsonString = await rootBundle.loadString(_filePath);
+      return json.decode(jsonString);
   }
 
   /// 指定したAPI名のキーを取得します。

--- a/lib/repository/api_json_repository.dart
+++ b/lib/repository/api_json_repository.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:svhw_app/repository/external_json_repository.dart';
+
+/// api_key.json の読み込みを行うリポジトリです。
+class ApiJsonRepositoryImpl implements ExternalJsonRepository {
+  /// 読み込むJSONのファイルパス
+  static const String _filePath = 'json/api_keys.json';
+
+  /// 読み込んだJSONのリスト
+  List<dynamic> _jsonArray = [];
+
+  @override
+  String getValue(String key, [int index = 0]) {
+    if (key.isEmpty) {
+      return '';
+    }
+
+    if (_jsonArray.isEmpty) {
+      return '';
+    }
+    return _jsonArray[index][key];
+  }
+
+  @override
+  Future<void> fetchJsonFile() async {
+    if (_jsonArray.isNotEmpty) return;
+    String jsonString = await rootBundle.loadString(_filePath);
+    _jsonArray = json.decode(jsonString);
+  }
+
+  /// 指定したAPI名のキーを取得します。
+  String getKeyByApiName(String apiName) {
+    if (apiName.isEmpty) {
+      return '';
+    }
+
+    if (_jsonArray.isEmpty) {
+      return '';
+    }
+
+    for (Map<String, dynamic> element in _jsonArray) {
+      if (apiName == element['name']) {
+        return element['key'];
+      }
+    }
+    return '';
+  }
+}

--- a/lib/repository/external_json_repository.dart
+++ b/lib/repository/external_json_repository.dart
@@ -1,7 +1,7 @@
 /// 外部ファイルのJSONから値を取得するリポジトリインターフェースです。
 abstract class ExternalJsonRepository {
   /// JSONファイルの内容を取得します。
-  Future<void> fetchJsonFile();
+  Future<List<dynamic>> fetchJsonFile();
   /// 指定したキーの値を取得します。
   /// 読み込むJSONが配列形式の場合はインデックスを指定して
   /// 指定行を読み込むこともできます。

--- a/lib/repository/external_json_repository.dart
+++ b/lib/repository/external_json_repository.dart
@@ -1,0 +1,9 @@
+/// 外部ファイルのJSONから値を取得するリポジトリインターフェースです。
+abstract class ExternalJsonRepository {
+  /// JSONファイルの内容を取得します。
+  Future<void> fetchJsonFile();
+  /// 指定したキーの値を取得します。
+  /// 読み込むJSONが配列形式の場合はインデックスを指定して
+  /// 指定行を読み込むこともできます。
+  String getValue(String key, [int index = 0]);
+}

--- a/lib/view/parts/icon.dart
+++ b/lib/view/parts/icon.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:svhw_app/provider/provider.dart';
+
 import '../../constant//my_flutter_app_icons.dart';
+import '../../provider/notifier/api_json_repository_notifier.dart';
+import '../../repository/api_json_repository.dart';
 
 /// その日の天気予報を取得し、天気に合ったアイコンを
 /// 取得できるクラスです。
-class WeatherIcon extends StatelessWidget {
+class WeatherIcon extends ConsumerWidget {
   const WeatherIcon({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return _Weather.rainy.icon;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ApiJsonRepositoryNotifier apiJsonNotifier =
+        ref.watch(AppProvider.apiJsonNotifierProvider.notifier);
+
+    return ref.read(apiJsonNotifier.fetchJsonFile()).when(
+        data: (_) {
+          String apiKey = ref.read(AppProvider.apiJsonNotifierProvider.notifier).getKeyByApiName(ref, 'Weather');
+          return const Icon(Icons.wb_sunny, color: Colors.redAccent);
+        },
+        error: (_, __) => const Icon(Icons.error),
+        loading: () => const CircularProgressIndicator());
   }
 }
 

--- a/lib/view/parts/icon.dart
+++ b/lib/view/parts/icon.dart
@@ -3,8 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/provider/provider.dart';
 
 import '../../constant//my_flutter_app_icons.dart';
-import '../../provider/notifier/api_json_repository_notifier.dart';
-import '../../repository/api_json_repository.dart';
 
 /// その日の天気予報を取得し、天気に合ったアイコンを
 /// 取得できるクラスです。
@@ -13,12 +11,12 @@ class WeatherIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ApiJsonRepositoryNotifier apiJsonNotifier =
+    final apiJsonNotifier =
         ref.watch(AppProvider.apiJsonNotifierProvider.notifier);
 
-    return ref.read(apiJsonNotifier.fetchJsonFile()).when(
+    return ref.watch(AppProvider.apiJsonNotifierProvider).when(
         data: (_) {
-          String apiKey = ref.read(AppProvider.apiJsonNotifierProvider.notifier).getKeyByApiName(ref, 'Weather');
+          String apiKey = apiJsonNotifier.getKeyByApiName('Weather');
           return const Icon(Icons.wb_sunny, color: Colors.redAccent);
         },
         error: (_, __) => const Icon(Icons.error),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
      - assets/  #assets 配下を読み込む
+     - json/
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
## 概要
JSONファイルを読み込みWeather API 実行に必要なAPIキーを取得する処理を追加しました。
仕組みとしては、ApiJsonRepositoryImpl でJSONファイルの読み込み及びファイル内容の保持を行い、
ApiJsonRepositoryNotifier で ApiJsonRepositoryImpl  の各処理の呼び出しとViewへのデータ受け渡しを行います。

## 問題
View側ではApiJsonRepositoryNotifier#fetchJsonFile() の結果を FutureProvider#when() で処理しているのですが、
JSONファイルの読み込みが終わっても常に loading となり、無限ループに近い動きになってしまっています。