### PR TITLE
[add] #6 天気情報取得時に表示するインジケーターのサイズを調整する

### DIFF
--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
-import 'package:svhw_app/provider/notifier/api_json_repository_notifier.dart';
 import 'package:svhw_app/provider/notifier/homework_notifier.dart';
 import 'package:svhw_app/provider/notifier/vacation_period_notifier.dart';
 import 'package:svhw_app/repository/api_json_repository.dart';

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
 import 'package:svhw_app/repository/homepage_repository.dart';
-import 'package:svhw_app/view/parts/progress_indicator.dart';
 import 'package:svhw_app/view/parts/icon.dart';
+import 'package:svhw_app/view/parts/progress_indicator.dart';
 
 /// 現在の宿題の状況を確認できるページです。
 /// 宿題が既に登録されている場合は最初に表示されるページになります。
@@ -27,10 +27,14 @@ class HomePage extends ConsumerWidget {
             const Text('ホーム画面だよー。'),
             Row(
               children: [
-                Container(padding: const EdgeInsets.only(left: 8),
+                Container(
+                    padding: const EdgeInsets.only(left: 8),
                     width: 300,
                     child: const VacationPeriodIndicator()),
-                const Expanded(child: WeatherIcon()),
+                Flexible(
+                    child: Container(
+                        alignment: Alignment.center,
+                        child: const WeatherIcon())),
               ],
             ),
             Text('夏休みの始まり -> ${period.dispStartDate}'),

--- a/lib/view/parts/icon.dart
+++ b/lib/view/parts/icon.dart
@@ -30,7 +30,6 @@ class WeatherIcon extends ConsumerWidget {
           return weatherIcon;
         },
         error: (_, __) => const Icon(Icons.error),
-        loading: () => const SizedBox(
-            height: 16, width: 16, child: CircularProgressIndicator()));
+        loading: () => const CircularProgressIndicator());
   }
 }


### PR DESCRIPTION
## 概要
ホームページで天気情報取得中に表示するインジケーターが引き伸ばされて表示されていたため、
引き伸ばさないように修正しました。

## 原因
ホームページ側で天気情報のアイコンを Expanded ウィジェットでラップしていたことが原因でした。
Expanded ウィジェットの仕様として Expanded で指定しているサイズより小さいウィジェットを子ウィジェットに指定
した場合は Expanded のサイズに合わせて引き伸ばされます(最大サイズとして表示される)。
そのため、子ウィジェットが親ウィジェットより小さい場合に子ウィジェットのサイズで表示される Flexble ウィジェットで
ラップするようにしました。

## 参考記事
https://zenn.dev/pressedkonbu/articles/flexible-vs-expanded
