### PR TITLE
[add] #6 ホームページにボトムナビゲーションバーを追加する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/constant/colors.dart';
 import 'package:svhw_app/constant/constant.dart';
-import 'package:svhw_app/view/home_page.dart';
 import 'package:svhw_app/view/register_homework_page.dart';
+import 'package:svhw_app/view/svhw_home_page.dart';
 import 'package:svhw_app/view/vacation_period_page.dart';
 
 import 'objectbox.g.dart';
@@ -83,7 +83,7 @@ class MyHomePage extends StatelessWidget {
           onPressed: () {
             Navigator.of(context).push(MaterialPageRoute(
                 builder: (BuildContext context) =>
-                const HomePage()));
+                const SvhwHomePage()));
           },
           child: const Text('宿題の進捗確認画面')),
     ];

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -66,4 +66,7 @@ class AppProvider {
     WeatherRepository weatherRepository = WeatherRepositoryImpl(apiKey);
     return weatherRepository.getCurrentWeatherByLocation(currentPosition);
   });
+
+  /// ホーム画面での表示ページを監視するプロバイダーです。
+  static final selectPageProvider = StateProvider<int>((_) => 0);
 }

--- a/lib/view/parts/bottom_navigation_bar.dart
+++ b/lib/view/parts/bottom_navigation_bar.dart
@@ -1,16 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:svhw_app/constant/constant.dart';
 
+import '../../constant/colors.dart';
+import '../../provider/provider.dart';
+
 /// ホームページで使用するボトムナビゲーションバーです。
-class HomePageBottomNavigationBar extends StatelessWidget {
+class HomePageBottomNavigationBar extends ConsumerWidget {
   const HomePageBottomNavigationBar({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return BottomNavigationBar(items: const <BottomNavigationBarItem>[
-      BottomNavigationBarItem(icon: Icon(Icons.home_rounded), label: Constant.homeMessage),
-      BottomNavigationBarItem(icon: Icon(Icons.add_task_rounded), label: Constant.registerMessage),
-    ],
+  Widget build(BuildContext context, WidgetRef ref) {
+    final int selectPage = ref.watch(AppProvider.selectPageProvider);
+
+    return BottomNavigationBar(
+      selectedItemColor: Colors.black,
+      unselectedItemColor: Colors.white,
+      type: BottomNavigationBarType.shifting,
+      currentIndex: selectPage,
+      onTap: (index) => ref
+          .read(AppProvider.selectPageProvider.notifier)
+          .update((_) => index),
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+            backgroundColor: AppColor.mainColor,
+            icon: Icon(Icons.home_rounded), label: Constant.homeMessage),
+        BottomNavigationBarItem(
+            backgroundColor: AppColor.mainColor,
+            icon: Icon(Icons.add_task_rounded),
+            label: Constant.registerMessage),
+      ],
     );
   }
 }

--- a/lib/view/register_progress_page.dart
+++ b/lib/view/register_progress_page.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,8 +9,10 @@ class RegisterProgressPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // TODO: implement build
-    throw UnimplementedError();
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('宿題の進捗登録画面'),
+        ),
+        body: const Text('進捗の登録画面です'));
   }
-
 }

--- a/lib/view/svhw_home_page.dart
+++ b/lib/view/svhw_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:svhw_app/provider/provider.dart';
 import 'package:svhw_app/view/home_page.dart';
 import 'package:svhw_app/view/parts/bottom_navigation_bar.dart';
 import 'package:svhw_app/view/register_progress_page.dart';
@@ -13,14 +14,14 @@ class SvhwHomePage extends ConsumerWidget {
     RegisterProgressPage()
   ];
 
-  /// 選択中のページ
-  /// TODO:Providerで管理したほうがいいかも
-  int _selectPage = 0;
+  /// コンストラクタ
+  const SvhwHomePage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final int selectPage = ref.watch(AppProvider.selectPageProvider);
     return Scaffold(
-      body: _pages[_selectPage],
+      body: _pages[selectPage],
       bottomNavigationBar: const HomePageBottomNavigationBar(),
     );
   }


### PR DESCRIPTION
## 概要
ホームページにボトムナビゲーションバーを追加し、宿題の進捗確認画面と進捗登録画面を切り替えられるようにしました。
初期表示は進捗確認画面です。
選択ページのインデックスはRiverpodで管理するようにしています。