### PR TITLE
[add] #6 夏休み日数のインジケーターと天気のアイコンの間に今日の日付けを表示する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -55,8 +55,11 @@ class Constant {
   /// メッセージ：ホーム
   static const String homeMessage = 'ホーム';
 
-  /// 本アプリで使用する日付のフォーマット
-  static final DateFormat formatter = DateFormat('yyyy/MM/dd', 'ja-JP');
+  /// 日付(yyyy/MM/dd)のフォーマット
+  static final DateFormat slashSeparateFormat = DateFormat('yyyy/MM/dd', 'ja-JP');
+
+  /// 日付(MM月dd日)のフォーマット
+  static final DateFormat japanDateFormat = DateFormat('MM月dd日', 'ja-JP');
 
   /// 本アプリで選択できる宿題の教科
   static final List<String> subjects = [

--- a/lib/model/vacation_period.dart
+++ b/lib/model/vacation_period.dart
@@ -19,10 +19,10 @@ class VacationPeriod {
   VacationPeriod({this.id = 0, required this.startDate, required this.endDate});
 
   /// 表示用(文字列)の開始日を返します。
-  String get dispStartDate => Constant.formatter.format(startDate);
+  String get dispStartDate => Constant.slashSeparateFormat.format(startDate);
 
   /// 表示用(文字列)の終了日を返します。
-  String get dispEndDate => Constant.formatter.format(endDate);
+  String get dispEndDate => Constant.slashSeparateFormat.format(endDate);
 
   /// オブジェクトのコピーを行います。
   VacationPeriod copyWith({DateTime? startDate, DateTime? endDate}) {

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -27,7 +27,7 @@ class AppProvider {
   static final startDateControllerStateProvider =
   StateProvider.autoDispose((ref) {
     return TextEditingController(
-        text: Constant.formatter.format(DateTime.now()));
+        text: Constant.slashSeparateFormat.format(DateTime.now()));
   });
 
   /// 夏休みの期間登録画面の入力フィールド
@@ -35,7 +35,7 @@ class AppProvider {
   static final endDateControllerStateProvider =
   StateProvider.autoDispose((ref) {
     return TextEditingController(
-        text: Constant.formatter.format(DateTime(
+        text: Constant.slashSeparateFormat.format(DateTime(
             DateTime
                 .now()
                 .year, DateTime.august, Constant.thirtyOneDays)));

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -6,6 +6,8 @@ import 'package:svhw_app/repository/homepage_repository.dart';
 import 'package:svhw_app/view/parts/icon.dart';
 import 'package:svhw_app/view/parts/progress_indicator.dart';
 
+import '../constant/constant.dart';
+
 /// 現在の宿題の状況を確認できるページです。
 /// 宿題が既に登録されている場合は最初に表示されるページになります。
 class HomePage extends ConsumerWidget {
@@ -29,8 +31,12 @@ class HomePage extends ConsumerWidget {
               Row(
                 children: [
                   const SizedBox(
-                      width: 300,
+                      width: 250,
                       child: VacationPeriodIndicator()),
+                  // その日の日付けを表示
+                  Container(
+                    padding: const EdgeInsets.all(8.0),
+                      child: Text(Constant.japanDateFormat.format(DateTime.now()))),
                   Flexible(
                       child: Container(
                           alignment: Alignment.center,

--- a/lib/view/vacation_period_page.dart
+++ b/lib/view/vacation_period_page.dart
@@ -49,7 +49,7 @@ class VacationPeriodPage extends ConsumerWidget {
                         if (value != DateTime.now()) {
                           TextEditingController controller = ref.read(
                               AppProvider.startDateControllerStateProvider);
-                          controller.text = Constant.formatter.format(value!);
+                          controller.text = Constant.slashSeparateFormat.format(value!);
                         }
                       });
                     },
@@ -81,7 +81,7 @@ class VacationPeriodPage extends ConsumerWidget {
                         if (value != DateTime.now()) {
                           TextEditingController controller = ref
                               .read(AppProvider.endDateControllerStateProvider);
-                          controller.text = Constant.formatter.format(value!);
+                          controller.text = Constant.slashSeparateFormat.format(value!);
                         }
                       });
                     },
@@ -94,10 +94,10 @@ class VacationPeriodPage extends ConsumerWidget {
               child: ElevatedButton(
                   // 次へタップ時に期間のデータ登録
                   onPressed: () {
-                    DateTime startDate = Constant.formatter.parseStrict(ref
+                    DateTime startDate = Constant.slashSeparateFormat.parseStrict(ref
                         .read(AppProvider.startDateControllerStateProvider)
                         .text);
-                    DateTime endDate = Constant.formatter.parseStrict(ref
+                    DateTime endDate = Constant.slashSeparateFormat.parseStrict(ref
                         .read(AppProvider.endDateControllerStateProvider)
                         .text);
                     ref


### PR DESCRIPTION
## 概要
夏休みの期間のインジケーターと天気のアイコンの間にその日の日付けを表示するようにしました。
