### PR TITLE
[clean] #53 各ページのタイトルを定数として定義する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -25,6 +25,18 @@ class Constant {
   /// 期間登録画面の横の余白
   static const double vacationPeriodPageVerticalPadding = 50;
 
+  /// ページタイトル：夏休みの期間登録画面
+  static const String vacationPeriodPageTitle = '夏休みの期間を登録';
+
+  /// ページタイトル：夏休みの宿題登録画面
+  static const String registerHomeworkPageTitle = '宿題の内容を登録';
+
+  /// ページタイトル：宿題の進捗確認画面
+  static const String homePageTitle = 'ホーム';
+
+  /// ページタイトル：宿題の進捗確認画面
+  static const String registerProgressPageTitle = '今日やったこと';
+
   /// メッセージ：夏休みの始まり
   static const String vacationStartDateMessage = '夏休みのはじまり';
 

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -21,7 +21,7 @@ class HomePage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('宿題の進捗確認画面'),
+        title: const Text(Constant.homePageTitle),
       ),
       body: Container(
         padding: const EdgeInsets.all(16.0),

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -21,7 +21,7 @@ class RegisterHomeworkPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('夏休みの宿題登録画面'),
+        title: const Text(Constant.registerHomeworkPageTitle),
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(

--- a/lib/view/register_progress_page.dart
+++ b/lib/view/register_progress_page.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../constant/constant.dart';
 
 /// その日の宿題の進捗を登録する画面です。
 class RegisterProgressPage extends ConsumerWidget {
@@ -11,7 +11,7 @@ class RegisterProgressPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
         appBar: AppBar(
-          title: const Text('宿題の進捗登録画面'),
+          title: const Text(Constant.registerProgressPageTitle),
         ),
         body: const Text('進捗の登録画面です'));
   }

--- a/lib/view/vacation_period_page.dart
+++ b/lib/view/vacation_period_page.dart
@@ -15,7 +15,7 @@ class VacationPeriodPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('夏休みの期間登録画面'),
+        title: const Text(Constant.vacationPeriodPageTitle),
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
## 概要
各ページのタイトルが各クラスにハードコードしていたため、定数クラスに定数として定義し、定数化しました。