### PR TITLE
[add] #55 宿題の総数を登録できるフィールドを追加する

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -67,6 +67,9 @@ class Constant {
   /// メッセージ：ホーム
   static const String homeMessage = 'ホーム';
 
+  /// メッセージ：P/枚
+  static const String unitsMessage = 'P/枚';
+
   /// 日付(yyyy/MM/dd)のフォーマット
   static final DateFormat slashSeparateFormat = DateFormat('yyyy/MM/dd', 'ja-JP');
 

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -50,6 +50,7 @@ class AppProvider {
   static final selectSubjectProvider =
   StateProvider.autoDispose((ref) => Constant.dropDownItems[0]);
 
+  /// 宿題の種類を管理するプロバイダーです。
   static final selectTypeProvider =
   StateProvider.autoDispose((ref) => HomeworkType.text);
 

--- a/lib/view/parts/dropdown_button.dart
+++ b/lib/view/parts/dropdown_button.dart
@@ -22,8 +22,7 @@ class SubjectDropdownButton extends ConsumerWidget {
             value: subject,
             child: Text(subject),
           );
-        }).toList()
-    );
+        }).toList());
   }
 }
 

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:svhw_app/constant/constant.dart';
@@ -46,7 +47,9 @@ class RegisterHomeworkPage extends ConsumerWidget {
                           children: [
                             SlidableAction(
                               onPressed: (context) {
-                                ref.read(AppProvider.homeworksProvider.notifier)
+                                ref
+                                    .read(
+                                        AppProvider.homeworksProvider.notifier)
                                     .removeHomeWork(homework.id);
                               },
                               flex: 2,
@@ -81,8 +84,7 @@ class RegisterHomeworkPage extends ConsumerWidget {
                         .read(AppProvider.homeworksProvider.notifier)
                         .insertHomeworks();
                     Navigator.of(context).push(MaterialPageRoute(
-                        builder: (BuildContext context) =>
-                        const HomePage()));
+                        builder: (BuildContext context) => const HomePage()));
                   },
                   child: const Text(Constant.registerMessage)),
             ),
@@ -105,11 +107,30 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
         builder: (BuildContext context) => AlertDialog(
           title: const Text(Constant.selectHomeworkMessage),
           content: SizedBox(
-            height: 100,
+            height: 150,
             child: Column(
-              children: const [
-                SubjectDropdownButton(),
-                HomeworkTypeDropdownButton(),
+              children: [
+                const SubjectDropdownButton(),
+                const HomeworkTypeDropdownButton(),
+                Container(
+                  alignment: Alignment.center,
+                  child: Row(
+                    children: [
+                      SizedBox(
+                          width: 55,
+                          height: 30,
+                          child: TextField(
+                            decoration: const InputDecoration(
+                                border: OutlineInputBorder()),
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly
+                            ],
+                          )),
+                      Text(_getHomeworkUnits(ref)),
+                    ],
+                  ),
+                )
               ],
             ),
           ),
@@ -140,5 +161,17 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
         style: TextStyle(fontSize: 20),
       ),
     );
+  }
+
+  /// 宿題の種類にあった単位を取得します。
+  String _getHomeworkUnits(WidgetRef ref) {
+    final HomeworkType selectType = ref.watch(AppProvider.selectTypeProvider);
+
+    switch (selectType) {
+      case HomeworkType.print:
+        return '枚';
+      case HomeworkType.text:
+        return 'P';
+    }
   }
 }

--- a/lib/view/register_homework_page.dart
+++ b/lib/view/register_homework_page.dart
@@ -109,27 +109,26 @@ class _SelectHomeworkDialogButton extends ConsumerWidget {
           content: SizedBox(
             height: 150,
             child: Column(
+
               children: [
                 const SubjectDropdownButton(),
                 const HomeworkTypeDropdownButton(),
-                Container(
-                  alignment: Alignment.center,
-                  child: Row(
-                    children: [
-                      SizedBox(
-                          width: 55,
-                          height: 30,
-                          child: TextField(
-                            decoration: const InputDecoration(
-                                border: OutlineInputBorder()),
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly
-                            ],
-                          )),
-                      Text(_getHomeworkUnits(ref)),
-                    ],
-                  ),
+                Row(
+                   mainAxisAlignment:  MainAxisAlignment.center,
+                  children: [
+                    SizedBox(
+                        width: 55,
+                        height: 30,
+                        child: TextField(
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder()),
+                          keyboardType: TextInputType.number,
+                          inputFormatters: [
+                            FilteringTextInputFormatter.digitsOnly
+                          ],
+                        )),
+                    const Text(Constant.unitsMessage),
+                  ],
                 )
               ],
             ),


### PR DESCRIPTION
## 概要
宿題の登録画面で科目、宿題の種類に追加で宿題の量を登録できるフィールドを追加しました。
フィールドの追加のみで以下の対応が残っています。

- フィールドの配置調整
- 宿題の種類によってフィールド右に表示する単位の状態管理
- ObjectBoxへの登録