### PR TITLE
[add] #55 宿題の量を登録する StateNotifier, Provider を追加する

### DIFF
--- a/lib/model/homework.dart
+++ b/lib/model/homework.dart
@@ -13,6 +13,7 @@ class Homework {
   /// 宿題の種別(テキスト or プリント)
   int homeworkType;
 
+  /// コンストラクタ
   Homework({this.id = 0, required this.subject, required this.homeworkType});
 }
 

--- a/lib/model/progress.dart
+++ b/lib/model/progress.dart
@@ -16,6 +16,9 @@ class Progress {
   /// 現在完了した数
   int completed;
 
+  // コンストラクタ
+  /// 先に Homework オブジェクトを生成し、宿題IDが
+  /// 裁判されてから呼び出すようにします。
   Progress(
       {this.id = 0,
       required this.homeworkId,

--- a/lib/provider/notifier/homework_notifier.dart
+++ b/lib/provider/notifier/homework_notifier.dart
@@ -2,16 +2,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../main.dart';
 import '../../model/homework.dart';
+import '../../objectbox.g.dart';
 
 /// 登録予定の宿題の StateNotifier です。
 class HomeworkNotifier extends StateNotifier<List<Homework>> {
   HomeworkNotifier(): super([]);
 
   /// 宿題のBox
-  final homeworkBox = store.box<Homework>();
+  final Box<Homework> homeworkBox = store.box<Homework>();
 
   /// 宿題を追加します。
-  /// DBへの登録は行わないません。
+  /// DBへの登録は行ないません。
   /// DBへ登録する場合はinsertHomeworks()を呼び出してください。
   void addHomeWork(Homework homework) {
     state = [...state, homework];

--- a/lib/provider/notifier/progress_notifier.dart
+++ b/lib/provider/notifier/progress_notifier.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../main.dart';
+import '../../model/progress.dart';
+import '../../objectbox.g.dart';
+
+/// 登録予定宿題の量の StateNotifier です。
+class ProgressNotifier extends StateNotifier<List<Progress>> {
+  ProgressNotifier(): super([]);
+
+  final Box<Progress> progressBox = store.box<Progress>();
+
+  /// 宿題の量を追加します。
+  /// DBへの登録は行いません。
+  void addHomeWork(Progress progress) {
+    state = [...state, progress];
+  }
+
+  /// IDを指定して宿題の量を削除します。
+  void removeProgress(int progressId) {
+    state = [
+      for (final progress in state)
+        if (progress.id != progressId) progress,
+    ];
+  }
+
+  /// ProgressNotifier で管理している宿題の量を登録します。
+  /// 夏休みの宿題登録画面で選択された宿題の量です。
+  void insertHomeworks() {
+    for (var progress in state) {
+      progressBox.put(progress);
+    }
+  }
+}

--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:svhw_app/model/homework.dart';
 import 'package:svhw_app/model/vacation_period.dart';
 import 'package:svhw_app/provider/notifier/homework_notifier.dart';
+import 'package:svhw_app/provider/notifier/progress_notifier.dart';
 import 'package:svhw_app/provider/notifier/vacation_period_notifier.dart';
 import 'package:svhw_app/repository/api_json_repository.dart';
 import 'package:svhw_app/repository/location_repository.dart';
@@ -11,6 +12,7 @@ import 'package:svhw_app/repository/weather_repository.dart';
 
 import '../constant/constant.dart';
 import '../constant/enum/weather_type.dart';
+import '../model/progress.dart';
 
 /// アプリ内で使用するプロバイダーを定義するクラスです。
 class AppProvider {
@@ -18,14 +20,14 @@ class AppProvider {
   /// 夏休みの開始日と終了日の状態を監視します。
   /// 夏休みの期間登録画面で使用します。
   static final periodProvider =
-  StateNotifierProvider<VacationPeriodNotifier, VacationPeriod>((ref) {
+      StateNotifierProvider<VacationPeriodNotifier, VacationPeriod>((ref) {
     return VacationPeriodNotifier();
   });
 
   /// 夏休みの期間登録画面の入力フィールド
   /// 夏休みの開始日のプロバイダーです。
   static final startDateControllerStateProvider =
-  StateProvider.autoDispose((ref) {
+      StateProvider.autoDispose((ref) {
     return TextEditingController(
         text: Constant.slashSeparateFormat.format(DateTime.now()));
   });
@@ -33,31 +35,37 @@ class AppProvider {
   /// 夏休みの期間登録画面の入力フィールド
   /// 夏休みの終了日のプロバイダーです。
   static final endDateControllerStateProvider =
-  StateProvider.autoDispose((ref) {
+      StateProvider.autoDispose((ref) {
     return TextEditingController(
         text: Constant.slashSeparateFormat.format(DateTime(
-            DateTime
-                .now()
-                .year, DateTime.august, Constant.thirtyOneDays)));
+            DateTime.now().year, DateTime.august, Constant.thirtyOneDays)));
   });
 
   /// 登録する宿題を管理するプロバイダーです。
   static final homeworksProvider =
-  StateNotifierProvider<HomeworkNotifier, List<Homework>>(
+      StateNotifierProvider<HomeworkNotifier, List<Homework>>(
           (ref) => HomeworkNotifier());
+
+  /// 登録する宿題の量を管理するプロバイダーです。
+  /// 宿題の内容登録画面でのみ使用します。
+  /// 宿題登録後の日々の進捗登録では使用しないでください。
+  static final progressProvider =
+      StateNotifierProvider<ProgressNotifier, List<Progress>>(
+          (ref) => ProgressNotifier());
 
   /// 科目選択プルダウンの選択値を管理するプロバイダーです。
   static final selectSubjectProvider =
-  StateProvider.autoDispose((ref) => Constant.dropDownItems[0]);
+      StateProvider.autoDispose((ref) => Constant.dropDownItems[0]);
 
   /// 宿題の種類を管理するプロバイダーです。
   static final selectTypeProvider =
-  StateProvider.autoDispose((ref) => HomeworkType.text);
+      StateProvider.autoDispose((ref) => HomeworkType.text);
 
   /// 現在地の天気情報を監視するプロバイダーです。
   static final weatherProvider = FutureProvider<WeatherType>((ref) async {
     LocationRepositoryImpl locationRepository = LocationRepositoryImpl();
-    final Position currentPosition = await locationRepository.getCurrentPosition();
+    final Position currentPosition =
+        await locationRepository.getCurrentPosition();
     currentPosition.longitude;
 
     final ApiJsonRepositoryImpl apiJsonRepository = ApiJsonRepositoryImpl();


### PR DESCRIPTION
## 概要
登録する宿題の量をDBに登録する StateNotifier と Provider を追加しました。

## 課題
- 宿題の量初期登録のProviderと日々の進捗登録で使用するProviderをわかりやすくしたい。
- 宿題の内容登録と量の登録を上手く実装できるなら1つの StateNotifier で管理できた方がいいかも。